### PR TITLE
Add support for extracting source/detekt rule id

### DIFF
--- a/lib/kotlin_detekt/plugin.rb
+++ b/lib/kotlin_detekt/plugin.rb
@@ -141,13 +141,14 @@ module Danger
         next unless !filtering || (target_files.include? filename)
         line = r.get("line") || "N/A"
         reason = r.get("message")
+        rule = r.get("source")
         count += 1
-        message << "`#{filename}` | #{line} | #{reason} \n"
+        message << "`#{filename}` | #{line} | #{reason} | #{rule} \n"
       end
       if count != 0
         header = "#### #{heading} (#{count})\n\n"
-        header << "| File | Line | Reason |\n"
-        header << "| ---- | ---- | ------ |\n"
+        header << "| File | Line | Reason | Rule |\n"
+        header << "| ---- | ---- | ------ | ---- |\n"
         message = header + message
       end
 


### PR DESCRIPTION
`source` or `detekt rule id` would be helpful for PR author to 
- Look up https://detekt.dev/docs/rules/comments for a more detailed explanation of specific rules.
- Suppress issues if needed.